### PR TITLE
fix(ssh): enable DSA host keys and add per-device SSH toggles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,14 @@ if(CUBESHELL_WITH_SSH)
         set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
         set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
         find_package(OpenSSL REQUIRED)
+        # 老旧设备(OpenSSH < 7 / 老交换机·路由器等网络设备)只提供 DSA 主机密钥
+        # (ssh-dss)。libssh2 1.11.1 默认把 DSA 关掉了,导致这些设备 KEX 协商不出
+        # 共同主机密钥算法,握手直接报 "SSH handshake failed:
+        # Unable to exchange encryption keys"。这里显式开启 DSA 支持。
+        # 用 target_compile_definitions 只影响 libssh2_static 这一个库,不改全局
+        # CMAKE_C_FLAGS,不会污染本项目其余目标。
         FetchContent_MakeAvailable(libssh2)
+        target_compile_definitions(libssh2_static PRIVATE LIBSSH2_DSA_ENABLE)
         set(LIBSSH2_FOUND TRUE)
         set(LIBSSH2_INCLUDE_DIRS ${libssh2_SOURCE_DIR}/include)
         set(LIBSSH2_LIBRARIES libssh2_static OpenSSL::SSL OpenSSL::Crypto)

--- a/src/core/config/DeviceConfigStore.cpp
+++ b/src/core/config/DeviceConfigStore.cpp
@@ -468,6 +468,10 @@ QJsonArray DeviceConfigStore::toJsonArray(bool withSecrets, bool withIds) const
         o[QStringLiteral("telnetNegotiate")] = e.telnetNegotiate;
         o[QStringLiteral("termType")]        = e.termType;
         o[QStringLiteral("autoLogin")]       = e.autoLogin;
+        // SSH 增强开关（新增 per-device 布尔；非 SSH 条目也一并写出，保持 IDE
+        // 与 JSON 结构一致的既有风格）。
+        o[QStringLiteral("directoryTracking")] = e.directoryTracking;
+        o[QStringLiteral("enableSftp")]        = e.enableSftp;
         // 代理字段（平铺成 proxyType/proxyHost/…，见 ProxyConfig::writeJson）。
         //
         // 代理口令**任何情况下都不写进 JSON**，包括 withSecrets 为真的迁移窗口期：
@@ -574,6 +578,10 @@ bool DeviceConfigStore::loadJson(const QString &jsonPath, QString *errorOut)
         e.termType = termType.isEmpty() ? QStringLiteral("xterm-256color") : termType;
         // autoLogin 缺键回落 false：自动送密码是需要用户显式开启的行为。
         e.autoLogin = o[QStringLiteral("autoLogin")].toBool(false);
+        // SSH 增强开关。缺键回落 true：目录追踪与 SFTP 都是默认开启的行为，
+        // 缺键回落成 false 会让已保存设备表现得和新建的不一样，故默认开启。
+        e.directoryTracking = o[QStringLiteral("directoryTracking")].toBool(true);
+        e.enableSftp        = o[QStringLiteral("enableSftp")].toBool(true);
         // 代理字段。旧 devices.json 里这些键全都不存在 → fromJson 给出
         // type == None，即直连，行为与加代理功能之前逐字节一致。
         // proxyPassword 键不存在也不会被读（口令只在钥匙串里）。

--- a/src/core/config/DeviceConfigStore.h
+++ b/src/core/config/DeviceConfigStore.h
@@ -123,6 +123,16 @@ struct DeviceEntry {
     // 准确说明而不是抛 libssh2 原始错误（见 SftpBrowserWidget::setBastionProxied）。
     bool viaBastion = false;
 
+    // SSH 增强开关（仅 protocol == ssh 时生效；serial/telnet/tcp/rdp 不读）。
+    //
+    // directoryTracking：连接后是否注入 OSC7 目录追踪 shell hook。受限的
+    // 老设备（如 rbash、缺 awk/hostname 的网络设备）执行该 hook 会刷出一串
+    // "command not found"，关了它即可静默。
+    bool directoryTracking = true;
+    // enableSftp：连接后是否挂接左栏 SFTP 面板。不提供 SFTP 子系统的老设备
+    // 一挂就卡住/报错，关了则完全不起 SFTP 会话。
+    bool enableSftp = true;
+
     bool isRdp() const { return protocol == QLatin1String("rdp"); }
     bool isSerial() const { return protocol == QLatin1String("serial"); }
     bool isTcp() const { return protocol == QLatin1String("tcp"); }

--- a/src/ui/add_device_dialog.cpp
+++ b/src/ui/add_device_dialog.cpp
@@ -169,6 +169,20 @@ AddDeviceDialog::AddDeviceDialog(QWidget *parent)
     // 类型切换会改变行数，跟着重算对话框高度。
     connect(m_proxy, &ProxySettingsWidget::typeChanged, this,
             &AddDeviceDialog::refitHeight);
+
+    // SSH 增强开关（仅 SSH 可见，见 onProtocolChanged）。老设备两个都建议关闭：
+    // 受限 shell（rbash）跑目录追踪 hook 会刷 "command not found"；没有 SFTP
+    // 子系统的设备挂左栏 SFTP 会卡住。
+    m_dirTracking = new QCheckBox(tr("目录追踪（OSC7，终端同步当前路径）"), this);
+    m_dirTracking->setChecked(true);
+    m_sftpToggle = new QCheckBox(tr("启用 SFTP（连接后在左侧显示远程文件）"), this);
+    m_sftpToggle->setChecked(true);
+    m_dirTracking->setToolTip(
+        tr("关闭后不注入 OSC7 目录追踪 hook，适合受限 shell / 老设备的连接。"));
+    m_sftpToggle->setToolTip(
+        tr("关闭后不挂接左侧 SFTP 面板，适合不支持 SFTP 子系统的设备。"));
+    form->addRow(QString(), m_dirTracking);
+    form->addRow(QString(), m_sftpToggle);
 #ifdef CUBESHELL_WITH_RDP
     // RDP 认证方式 + 域（仅 RDP 时可见）。
     // 对应Python: _inject_protocol_fields（cube-shell.py:6024-6033）
@@ -376,6 +390,10 @@ void AddDeviceDialog::setDevice(const DeviceEntry &e)
     netcombo::selectData(m_netNewline, int(ns.newlineMode));
     m_netLocalEcho->setChecked(ns.localEcho);
     m_netRxImplicitCr->setChecked(ns.rxImplicitCr);
+
+    // SSH 增强开关。
+    m_dirTracking->setChecked(e.directoryTracking);
+    m_sftpToggle->setChecked(e.enableSftp);
 
     m_name->setText(e.name);
     m_username->setText(e.username);
@@ -617,6 +635,8 @@ DeviceEntry AddDeviceDialog::device() const
         e.keyFile.clear();
     }
     e.agentForwarding = m_agentForward->isChecked();
+    e.directoryTracking = m_dirTracking->isChecked();
+    e.enableSftp        = m_sftpToggle->isChecked();
     // 代理只对 SSH 取值：上面 4 个提前 return（串口 / telnet+tcp / RDP）都不
     // 经过这里，于是那些协议的条目 proxy.type 恒为 None——与本轮"只接线 SSH"
     // 的范围一致（见 SshClient::setProxyConfig），也不会在 devices.json 里
@@ -711,6 +731,8 @@ void AddDeviceDialog::onProtocolChanged(int /*index*/)
     // 代理只有 SSH 需要：本轮只给 SSH 接线（Telnet/TCP 走 TcpClient，是另一条
     // 建连路径）。给 RDP/串口显示一个连接期不会被读的代理配置，比不显示更糟。
     m_form->setRowVisible(m_proxy, isSsh);
+    m_form->setRowVisible(m_dirTracking, isSsh);
+    m_form->setRowVisible(m_sftpToggle, isSsh);
     if (!isSsh)
         m_authMethod->setCurrentIndex(0);
     m_authStack->setCurrentIndex(isSsh ? m_authMethod->currentIndex() : 0);

--- a/src/ui/add_device_dialog.h
+++ b/src/ui/add_device_dialog.h
@@ -147,6 +147,11 @@ private:
     // 只有用户已经在用 agent 时才有意义。
     QCheckBox *m_agentForward = nullptr;
 
+    // SSH 增强开关（仅 SSH 可见）。目录追踪 = 连接后注入 OSC7 目录追踪 hook；
+    // SFTP 开关 = 连接后是否挂接左栏 SFTP 面板。受限/无 SFTP 的老设备关闭它。
+    QCheckBox *m_dirTracking = nullptr;
+    QCheckBox *m_sftpToggle = nullptr;
+
     // 端口框里当前放的是哪个协议的默认值。切协议时据此判断"用户没改过端口"，
     // 从而可以安全地换成新协议的默认端口（用户手填过的端口不动）。
     QString m_portDefaultFor;

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -3126,10 +3126,13 @@ void MainWindow::openSshSession(const DeviceEntry &stub)
         setTabConnected(tab, true);
         // 连接成功 → 把会话的 SFTP 浏览器挂到左侧面板（reparent 到 stack）。
         // 对应Python: on_ssh_connected 后左侧 treeWidget 展示远程文件树
-        if (SftpBrowserWidget *browser = tab->sftpBrowser()) {
-            if (m_browserStack->indexOf(browser) < 0) {
-                m_browserStack->addWidget(browser);
-                m_tabBrowsers.insert(tab, browser);
+        // enableSftp 关闭（老设备无 SFTP 子系统）时不挂左栏，避免出现卡住的空面板。
+        if (device.enableSftp) {
+            if (SftpBrowserWidget *browser = tab->sftpBrowser()) {
+                if (m_browserStack->indexOf(browser) < 0) {
+                    m_browserStack->addWidget(browser);
+                    m_tabBrowsers.insert(tab, browser);
+                }
             }
         }
         updateLeftPanel();

--- a/src/ui/ssh_session_tab.cpp
+++ b/src/ui/ssh_session_tab.cpp
@@ -35,7 +35,11 @@ SshSessionTab::SshSessionTab(const DeviceEntry &device, QWidget *parent)
         // 挂接 SFTP（初始目录：OSC7 首个 cwd 或 "/"，见 MainWindow 侧接线）。
         // 传 shared_ptr：让 SftpBrowserWidget 共享 SshClient 所有权，保证应用关闭
         // 时 client 比 SftpClient 后析构（m_monitor 的注释同此约定）。
-        if (m_term->sshClient())
+        //
+        // enableSftp 关闭时跳过 setClient：不提供 SFTP 子系统的老设备一旦尝试
+        // 打开 SFTP 会话就阻塞/报错，左栏表现为卡住。不 setClient 则面板保持
+        // 初始隐藏态，也不会有任何 SFTP 连接。
+        if (m_device.enableSftp && m_term->sshClient())
             m_sftp->setClient(m_term->sshClient());
         // 连接成功后启动监控采集线程。
         // 对应Python: ssh_func.py::get_datas 的后台线程启动

--- a/src/ui/ssh_terminal_widget.cpp
+++ b/src/ui/ssh_terminal_widget.cpp
@@ -393,7 +393,10 @@ void SshTerminalWidget::startConnect(const QString &password)
         // 含 __cs_osc7 的那一行，readline 重绘（\r + 提示符 + 历史 + \e[K，
         // 不带换行）显示层无法在不破坏重绘的前提下过滤——这正是上/下键显示
         // 异常的根因，必须让它根本不进历史。
-        client->writeChannel(SshBridge::shellHookCommand());
+        // 目录追踪开关：受限的/不兼容的远端 shell（如 rbash、缺 awk/hostname
+        // 的网络设备）执行该 hook 会刷一屏 "command not found"，关闭则跳过注入。
+        if (self->m_device.directoryTracking)
+            client->writeChannel(SshBridge::shellHookCommand());
 
         QMetaObject::invokeMethod(self, [self, client]() {
             if (!self)


### PR DESCRIPTION
## Summary
- Enable libssh2 DSA (ssh-dss) host-key support so legacy network devices (OpenSSH < 7) can complete the SSH handshake instead of failing with `SSH handshake failed: Unable to exchange encryption keys`.
- Add two per-device toggles: `directoryTracking` (skip the OSC7 directory-tracking shell hook on restricted shells) and `enableSftp` (skip the SFTP left panel / session on devices without an SFTP subsystem).

## Commits
- `fix(ssh)`: enable DSA host keys so legacy devices can establish KEX
- `feat(ssh)`: add per-device toggles for directory tracking and SFTP

## Test plan
- Rebuilt libssh2 with DSA enabled; verified `ssh-dss` present in the static lib and app binary.
- Verified handshake + password auth against legacy DSA-only SSH devices.
- Full project compiles cleanly.