### PR TITLE
feat(ui): tab keyboard shortcuts (Ctrl+Tab cycle & Ctrl+number jump)

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -45,6 +45,14 @@ set(UI_SOURCES
     editors/TextEditor.cpp
 )
 
+# macOS ⌃+Tab 原生捕获（NSEvent 本地监视器），Objective-C++。
+# 为什么必须原生：macOS 菜单栏键盘导航会在系统层截走 ⌃+Tab 并剥掉 ⌃ 修饰符，
+# Qt 侧（QShortcut/QAction/事件过滤）永远拿不到带 ⌃ 的按键。
+if(APPLE)
+    enable_language(OBJCXX)
+    list(APPEND UI_SOURCES platform/TabShortcutMonitor_mac.mm)
+endif()
+
 # Docker/内网穿透相关对话框与编辑器：后端 DockerManager/FrpManager 在
 # CUBESHELL_WITH_LOCALPROC=OFF（鸿蒙沙箱禁止 exec）时不编译，UI 同步摘除。
 # （TunnelConfigWidget 保留：主体走 TunnelPool/SSH 端口转发，frp 仅作可选

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -37,6 +37,9 @@
 #include <utility>
 
 #include "add_device_dialog.h"
+#ifdef Q_OS_MACOS
+#include "platform/TabShortcutMonitor.h"
+#endif
 #include "device_list_widget.h"
 #include "local_file_browser_widget.h"
 #include "sftp_browser_widget.h"
@@ -227,6 +230,10 @@ MainWindow::~MainWindow()
     // 置位析构标志：~QWidget 删子对象时各 tab 的 destroyed lambda 会检查它，
     // 避免在 hash 销毁中状态下访问 m_aiAgents（退出时 hash 随本对象整体销毁）。
     m_destroying = true;
+#ifdef Q_OS_MACOS
+    // 移除 ⌃+Tab 本地事件监视器，避免回调悬空。
+    removeMacTabShortcutMonitor();
+#endif
 }
 
 // ---------------------------------------------------------------------------
@@ -677,9 +684,18 @@ void MainWindow::setupMenus()
     closeTab->setShortcut(QKeySequence(QStringLiteral("Ctrl+W")));
     termMenu->addSeparator();
     QAction *next = termMenu->addAction(tr("下一个标签页"), this, &MainWindow::nextTab);
-    next->setShortcut(QKeySequence(QStringLiteral("Ctrl+Tab")));
     QAction *prev = termMenu->addAction(tr("上一个标签页"), this, &MainWindow::prevTab);
+#ifndef Q_OS_MACOS
+    // Windows/Linux：菜单 QAction 快捷键即可正常触发。
+    next->setShortcut(QKeySequence(QStringLiteral("Ctrl+Tab")));
     prev->setShortcut(QKeySequence(QStringLiteral("Ctrl+Shift+Tab")));
+#else
+    // macOS：若把 ⌃+Tab 设成菜单 action 快捷键，会被原生菜单栏键盘导航抢先接走
+    // 并闪一下不切换。因此这里不设 action 快捷键，改用原生 NSEvent 监视器捕获
+    // （见 setupShortcuts 里的 installMacTabShortcutMonitor），且菜单项不显示按键提示。
+    next->setShortcut(QKeySequence());
+    prev->setShortcut(QKeySequence());
+#endif
 
     // --- 工具 ---
     QMenu *toolsMenu = menuBar()->addMenu(tr("工具"));
@@ -876,6 +892,18 @@ static QString formatSpeed(double speed)
 void MainWindow::setupShortcuts()
 {
     // Ctrl+T/W/Tab 等已绑定在菜单 QAction 上（见 setupMenus），此处无需重复。
+
+#ifdef Q_OS_MACOS
+    // ⌃+Tab / ⌃⇧+Tab：macOS 菜单栏键盘导航会在系统层截走 ⌃+Tab 并剥掉 ⌃ 修饰符，
+    // Qt 的 QShortcut/QAction 永远拿不到带 ⌃ 的按键（日志已实证：到达应用的是
+    // mods=0x0 的裸 Tab）。故用原生 NSEvent 本地监视器在系统导航之前捕获。
+    installMacTabShortcutMonitor([this](bool backward) {
+        if (backward)
+            prevTab();
+        else
+            nextTab();
+    });
+#endif
 
     // 片段按钮栏显隐持久化（QSettings）；setupToolbar 已建栏，这里补可见性与快捷键。
     m_snippetBarVisible =

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -893,6 +893,21 @@ void MainWindow::setupShortcuts()
 {
     // Ctrl+T/W/Tab 等已绑定在菜单 QAction 上（见 setupMenus），此处无需重复。
 
+    // Ctrl+1..Ctrl+9 / Ctrl+0：跳到第 1~10 个标签页。
+    // Qt 的 "Ctrl" 字符串在 macOS 上自动映射成 ⌘（Command）键、其余平台映射成
+    // Ctrl，因此同一条即满足"macOS 用 Command+数字、其他系统按惯例用 Ctrl+数字"。
+    // Ctrl+1 → 标签1(下标0)……Ctrl+9 → 标签9(下标8)，Ctrl+0 → 标签10(下标9)。
+    // index 超出当前标签数时静默忽略。
+    for (int n = 0; n <= 9; ++n) {
+        const int tabIndex = (n == 0) ? 9 : n - 1;
+        auto *sc = new QShortcut(QKeySequence(QStringLiteral("Ctrl+%1").arg(n)), this);
+        connect(sc, &QShortcut::activated, this, [this, tabIndex]() {
+            QTabWidget *tabs = activeTabWidget();
+            if (tabs && tabIndex < tabs->count())
+                tabs->setCurrentIndex(tabIndex);
+        });
+    }
+
 #ifdef Q_OS_MACOS
     // ⌃+Tab / ⌃⇧+Tab：macOS 菜单栏键盘导航会在系统层截走 ⌃+Tab 并剥掉 ⌃ 修饰符，
     // Qt 的 QShortcut/QAction 永远拿不到带 ⌃ 的按键（日志已实证：到达应用的是

--- a/src/ui/platform/TabShortcutMonitor.h
+++ b/src/ui/platform/TabShortcutMonitor.h
@@ -1,0 +1,25 @@
+// TabShortcutMonitor.h — macOS ⌃+Tab / ⌃⇧+Tab 原生捕获（Objective-C++ 实现）。
+// 理由：macOS 菜单栏“键盘导航”会在系统层截走 ⌃+Tab 做“移动焦点”，并把原始
+// ⌃ 修饰符剥掉（到达应用的是一个 mods=0 的裸 Tab），导致 Qt 的 QShortcut/
+// QAction/事件过滤一律无法匹配。故与 SecureCRT 相同，用一个 NSEvent 本地监视器
+// 在系统菜单导航之前拿到带 ⌃ 修饰符的原始事件并切换标签。
+#pragma once
+
+#include <functional>
+
+#ifdef Q_OS_MACOS
+
+namespace cubeshell {
+
+// 安装本地监视器：拦截 ⌃+Tab / ⌃⇧+Tab。
+//   backward=false → 下一个标签；backward=true → 上一个标签。
+// 回调在主线程执行（本地事件监视器天然跑在主线程）。
+// 重复调用会先移除之前的监视器。
+void installMacTabShortcutMonitor(const std::function<void(bool backward)> &onCycle);
+
+// 移除监视器（内部自幂等；MainWindow 析构时调用）。
+void removeMacTabShortcutMonitor();
+
+} // namespace cubeshell
+
+#endif // Q_OS_MACOS

--- a/src/ui/platform/TabShortcutMonitor_mac.mm
+++ b/src/ui/platform/TabShortcutMonitor_mac.mm
@@ -1,0 +1,73 @@
+// TabShortcutMonitor_mac.mm — 在系统菜单导航截走 ⌃+Tab 之前，用 NSEvent 本地监视器
+// 捕获 https://developer.apple.com/documentation/appkit/nsevent/1534751-addlocalmonitorforevents 原始事件。
+// 仅在 APPLE 下编译（由 src/ui/CMakeLists.txt 的 if(APPLE) 分支加入源列表）。
+
+#ifdef __APPLE__
+
+#import <Cocoa/Cocoa.h>
+#include <Carbon/Carbon.h> // kVK_Tab 虚拟键码
+
+#include "TabShortcutMonitor.h"
+
+#include <functional>
+
+namespace cubeshell {
+namespace {
+
+struct TabShortcutState {
+    id monitor = nil;                 // 本地监视器句柄
+    std::function<void(bool)> onCycle; // 切换回调
+};
+
+TabShortcutState &state()
+{
+    static TabShortcutState s;
+    return s;
+}
+
+} // namespace
+
+void removeMacTabShortcutMonitor()
+{
+    if (state().monitor) {
+        [NSEvent removeMonitor:state().monitor];
+        state().monitor = nil;
+    }
+    state().onCycle = nullptr;
+}
+
+void installMacTabShortcutMonitor(const std::function<void(bool)> &onCycle)
+{
+    removeMacTabShortcutMonitor();
+    state().onCycle = onCycle;
+
+    // 传指针到函数级静态回调，处理器在主线程执行；remove() 后 onCycle 变空，
+    // handler 里调用前做空检查即可。局部监视器只对当前进程主线程事件流生效，
+    // 不会像全局监视器那样要求“辅助功能”权限。
+    const auto *cb = &state().onCycle;
+    state().monitor =
+        [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown
+                                              handler:^NSEvent *(NSEvent *event) {
+                                                    if ([event type] != NSEventTypeKeyDown)
+                                                        return event;
+                                                    const NSUInteger mods =
+                                                        [event modifierFlags] &
+                                                        NSEventModifierFlagDeviceIndependentFlagsMask;
+                                                    if ((mods & NSEventModifierFlagControl) == 0 ||
+                                                        [event keyCode] != kVK_Tab)
+                                                        return event;
+                                                    const BOOL backward =
+                                                        (mods & NSEventModifierFlagShift) != 0;
+                                                    // 长按不重复切换（isRepeat=true 时仅吞掉，
+                                                    // 不触发回调，避免卡死循环切换）。
+                                                    if (![event isARepeat] && cb && *cb)
+                                                        (*cb)(backward);
+                                                    // 返回 nil：彻底吞掉该按键，阻止菜单栏
+                                                    // 键盘导航截走 ⌃+Tab（也就是之前“菜单闪一下”的来源）。
+                                                    return nil;
+                                                }];
+}
+
+} // namespace cubeshell
+
+#endif // __APPLE__


### PR DESCRIPTION
## Summary
Add keyboard shortcuts for switching session tabs in the main window.

**1. Ctrl+Tab / Ctrl+Shift+Tab cycle** (`5c49f6e`): cycle to the next/previous tab. On macOS the menu-bar keyboard navigation intercepts ^Tab and strips the Control modifier before it reaches Qt, so this uses a local `NSEvent` monitor (SecureCRT-style) to capture ^Tab / ^Shift+Tab before the system does and to suppress the menu flash. Windows/Linux keep the existing menu-action `Ctrl+Tab` / `Ctrl+Shift+Tab` binding.

**2. Ctrl+number jump** (`c13a135`): jump directly to a tab — Ctrl+1..9 → tabs 1..9, Ctrl+0 → tab 10. Qt maps the `"Ctrl"` shortcut string to the Command key on macOS and Control on other platforms, so one binding satisfies both conventions (⌘+1..9/0 on macOS, Ctrl+1..9/0 elsewhere).

## Test plan
- macOS: ^Tab / ^Shift+Tab cycles tabs; ⌘+1..9 / ⌘+0 jumps to that tab.
- Windows/Linux: Ctrl+Tab / Ctrl+Shift+Tab cycles; Ctrl+1..9 / Ctrl+0 jumps.
- Multiple split panes: shortcuts act on the active pane's tab widget.

## Notes
- Base is `e1ec34d` (upstream `main`) as requested; the two commits do not include the DSA/device-toggle work.
- The macOS menu items intentionally do not display the shortcut hint (native monitor owns the binding).
